### PR TITLE
added Juneteenth National Independence Day

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "scripts": {
     "prepack": "tsc",
-    "prepare": "tsc",
     "lint": "eslint --ignore-path '.gitignore' '**/*.ts'",
     "format": "prettier --ignore-unknown --ignore-path '.gitignore' --write '**/*'",
     "test": "nyc mocha",

--- a/package.json
+++ b/package.json
@@ -36,9 +36,7 @@
     "posttest": "nyc report --reporter=text-lcov | codecov --pipe"
   },
   "files": [
-    "dist",
-    "src",
-    "tsconfig.json"
+    "dist"
   ],
   "keywords": [
     "holidays",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "posttest": "nyc report --reporter=text-lcov | codecov --pipe"
   },
   "files": [
-    "dist"
+    "dist",
+    "src",
+    "tsconfig.json"
   ],
   "keywords": [
     "holidays",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "scripts": {
     "prepack": "tsc",
+    "prepare": "tsc",
     "lint": "eslint --ignore-path '.gitignore' '**/*.ts'",
     "format": "prettier --ignore-unknown --ignore-path '.gitignore' --write '**/*'",
     "test": "nyc mocha",

--- a/src/common/util.spec.ts
+++ b/src/common/util.spec.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { getNthDay, getLastDay } from "./util";
+import { getNthDay, getLastDay, getNextPreviousWorkDay } from "./util";
 
 describe("nyse-holidays/common/util", function () {
   describe("getNthDay", function () {
@@ -40,6 +40,28 @@ describe("nyse-holidays/common/util", function () {
         month,
         day,
       })}).toDate().toDateString()`, function () {
+        assert.equal(dateString, expected);
+      });
+    });
+  });
+
+  describe("getNextPreviousWorkDay", function () {
+    [
+      { year: 2022, month: 5, day: 6, expected: "Fri May 06 2022" },
+      { year: 2022, month: 5, day: 7, expected: "Fri May 06 2022" },
+      { year: 2022, month: 5, day: 8, expected: "Mon May 09 2022" },
+      { year: 2022, month: 5, day: 9, expected: "Mon May 09 2022" },
+    ].forEach((param) => {
+      const { year, month, day, expected } = param;
+      const dateString = getNextPreviousWorkDay(param).toDate().toDateString();
+
+      it(`should return ${expected} for getNextPreviousWorkDay(${JSON.stringify(
+        {
+          year,
+          month,
+          day,
+        }
+      )}).toDate().toDateString()`, function () {
         assert.equal(dateString, expected);
       });
     });

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -28,6 +28,28 @@ export const getNthDay = (param: {
   return result;
 };
 
+export const getNextPreviousWorkDay = (param: {
+  year: number;
+  month: number;
+  day: number;
+}): dayjs.Dayjs => {
+  const { year, month, day } = param;
+
+  let result = getDate({ month, year, day });
+
+  if (result.day() == 0) {
+    //sunday
+    result = result.add(1, "day");
+  }
+
+  if (result.day() == 6) {
+    //saturday
+    result = result.subtract(1, "day");
+  }
+
+  return result;
+};
+
 export const getLastDay = (param: {
   year: number;
   month: number;

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -49,7 +49,7 @@ describe("nyse-holidays", function () {
       { year: 2022, month: 4, day: 15, expected: true }, // Good Friday
       { year: 2022, month: 5, day: 30, expected: true }, // Memorial Day
       /**
-       * starting 2022 is Juneteenth National Intependence Day 
+       * starting 2022 is Juneteenth National Intependence Day
        * https://www.cmegroup.com/content/dam/cmegroup/notices/ser/2021/12/SER-8887.pdf
        */
       { year: 2022, month: 6, day: 20, expected: true }, // Juneteenth National Independence Day

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -48,6 +48,11 @@ describe("nyse-holidays", function () {
       { year: 2022, month: 2, day: 21, expected: true }, // Washington's Birthday
       { year: 2022, month: 4, day: 15, expected: true }, // Good Friday
       { year: 2022, month: 5, day: 30, expected: true }, // Memorial Day
+      /**
+       * starting 2022 is Juneteenth National Intependence Day 
+       * https://www.cmegroup.com/content/dam/cmegroup/notices/ser/2021/12/SER-8887.pdf
+       */
+      { year: 2022, month: 6, day: 20, expected: true }, // Juneteenth National Independence Day
       { year: 2022, month: 7, day: 4, expected: true }, // Independence Day
       { year: 2022, month: 9, day: 5, expected: true }, // Labor Day
       { year: 2022, month: 11, day: 24, expected: true }, // Thanksgiving Day
@@ -58,6 +63,7 @@ describe("nyse-holidays", function () {
       { year: 2023, month: 4, day: 7, expected: true }, // Good Friday
       { year: 2023, month: 5, day: 29, expected: true }, // Memorial Day
       { year: 2023, month: 7, day: 4, expected: true }, // Independence Day
+      { year: 2023, month: 6, day: 19, expected: true }, // Juneteenth National Independence Day
       { year: 2023, month: 9, day: 4, expected: true }, // Labor Day
       { year: 2023, month: 11, day: 23, expected: true }, // Thanksgiving Day
       { year: 2023, month: 12, day: 25, expected: true }, // Christmas Day
@@ -75,8 +81,8 @@ describe("nyse-holidays", function () {
     [
       { year: 1800, expected: 0 },
       { year: 2021, expected: 9 },
-      { year: 2022, expected: 8 },
-      { year: 2023, expected: 9 },
+      { year: 2022, expected: 9 },
+      { year: 2023, expected: 10 },
     ].forEach((param) => {
       const { year, expected } = param;
       const length = getHolidays(year).length;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,11 @@
 import dayjs from "dayjs";
-import { getDate, getGoodFriday, getLastDay, getNthDay } from "./common/util";
+import {
+  getDate,
+  getGoodFriday,
+  getLastDay,
+  getNextPreviousWorkDay,
+  getNthDay,
+} from "./common/util";
 
 export type Holiday = {
   name: string;
@@ -31,6 +37,9 @@ export const getHolidays = (year: number): Holiday[] => {
 
   const memorialDay = MemorialDay(year);
   memorialDay && holidays.push(memorialDay);
+
+  const juneteenthDay = JuneteenthDay(year);
+  juneteenthDay && holidays.push(juneteenthDay);
 
   const independenceDay = IndependenceDay(year);
   independenceDay && holidays.push(independenceDay);
@@ -178,6 +187,16 @@ const MemorialDay = (year: number) => {
     return {
       name,
       date: getDate({ year, month: 5, day: 30 }),
+    };
+  }
+};
+
+const JuneteenthDay = (year: number) => {
+  // June 19th of each year going forward. If Saturday, closed the preceding Friday – if Sunday, closed the succeeding Monday.
+  if (year >= 2022) {
+    return {
+      name: "Juneteenth National Independence Day",
+      date: getNextPreviousWorkDay({ year, month: 6, day: 19 }),
     };
   }
 };


### PR DESCRIPTION
https://www.thecorporatecounsel.net/blog/2021/10/nyse-makes-juneteenth-a-new-market-holiday.html#:~:text=Under%20this%20change%20to%20NYSE,be%20closed%20the%20succeeding%20Monday.

Exchange will be closed on June 19th of each year going forward. If the holiday falls on a Saturday, the Exchange will be closed the preceding Friday – and if it falls on a Sunday, the Exchange will be closed the succeeding Monday. This rule change brings the number of NYSE market holidays to ten.

Added a new function to derive the next work day (or previous one if Saturday).

Added test cases accordingly